### PR TITLE
Setup logger before any other state/ops

### DIFF
--- a/lib/Vaultaire/Collector/Common/Process.hs
+++ b/lib/Vaultaire/Collector/Common/Process.hs
@@ -29,10 +29,10 @@ runCollector :: MonadIO m
              -> m ()
 runCollector parseExtraOpts initialiseExtraState cleanup collect = do
     (cOpts, eOpts) <- liftIO $ execParser (info (liftA2 (,) parseCommonOpts parseExtraOpts) fullDesc)
-    let opts = (cOpts, eOpts)
-    eState <- initialiseExtraState opts
-    cState <- getInitialCommonState cOpts
     liftIO $ setupLogger (optLogLevel cOpts)
+    let opts = (cOpts, eOpts)
+    cState <- getInitialCommonState cOpts
+    eState <- initialiseExtraState opts
     evalStateT (runReaderT (unCollector $ collect >> cleanup) opts) (cState, eState)
   where
     setupLogger level = do


### PR DESCRIPTION
Fixes the bug of potentially losing logs during setup of extra state because the global logger has not been set up at that time.
