### PR TITLE
No default namespace

### DIFF
--- a/lib/Vaultaire/Collector/Common/Process.hs
+++ b/lib/Vaultaire/Collector/Common/Process.hs
@@ -240,7 +240,6 @@ parseCommonOpts = CommonOpts
     <*> strOption
         (long "marquise-namespace"
          <> short 'm'
-         <> value "perfdata"
          <> metavar "MARQUISE-NAMESPACE"
          <> help "Marquise namespace to write to. Must be unique on a per-host basis.")
     <*> option auto

--- a/vaultaire-collector-common.cabal
+++ b/vaultaire-collector-common.cabal
@@ -2,7 +2,7 @@
 -- further documentation, see http://haskell.org/cabal/users-guide/
 
 name:                vaultaire-collector-common
-version:             0.4.0
+version:             0.4.1
 synopsis:            Common base for Haskell vaultaire collectors
 description:         Provides a framework for easily writing data to the vault
                      via spool files. Includes automatic spool file rotation,


### PR DESCRIPTION
marrquise namespace should not default to perfdata (or anything for that matter)