### PR TITLE
derive MonadThrow, Catch and Mask instances

### DIFF
--- a/lib/Vaultaire/Collector/Common/Types.hs
+++ b/lib/Vaultaire/Collector/Common/Types.hs
@@ -4,6 +4,7 @@
 module Vaultaire.Collector.Common.Types where
 
 import           Control.Applicative
+import           Control.Monad.Catch
 import           Control.Monad.Reader
 import           Control.Monad.State
 import           Data.Word
@@ -38,6 +39,10 @@ newtype Collector o s m a = Collector {
 } deriving (Functor, Applicative, Monad, MonadReader (CollectorOpts o), MonadState (CollectorState s))
 
 deriving instance MonadIO m => MonadIO (Collector o s m)
+
+deriving instance MonadThrow m => MonadThrow (Collector o s m)
+deriving instance MonadCatch m => MonadCatch (Collector o s m)
+deriving instance MonadMask m  => MonadMask  (Collector o s m)
 
 instance MonadTrans (Collector o s) where
     lift act = Collector $ lift $ lift act

--- a/vaultaire-collector-common.cabal
+++ b/vaultaire-collector-common.cabal
@@ -2,7 +2,7 @@
 -- further documentation, see http://haskell.org/cabal/users-guide/
 
 name:                vaultaire-collector-common
-version:             0.6.1
+version:             0.6.2
 synopsis:            Common base for Haskell vaultaire collectors
 description:         Provides a framework for easily writing data to the vault
                      via spool files. Includes automatic spool file rotation,
@@ -25,6 +25,7 @@ library
   exposed-modules:     Vaultaire.Collector.Common.Process
                        Vaultaire.Collector.Common.Types
   build-depends:       base >=4.7 && <4.8,
+                       exceptions,
                        mtl,
                        hslogger,
                        marquise >= 4.0 && < 5.0,


### PR DESCRIPTION
What it says on the tin. Primarily for being able to use in tandem with ListT for streaming vaultaire queries.