### PR TITLE
use RWST over chained StateT and ReaderT

### DIFF
--- a/vaultaire-collector-common.cabal
+++ b/vaultaire-collector-common.cabal
@@ -2,7 +2,7 @@
 -- further documentation, see http://haskell.org/cabal/users-guide/
 
 name:                vaultaire-collector-common
-version:             0.6.2
+version:             0.6.3
 synopsis:            Common base for Haskell vaultaire collectors
 description:         Provides a framework for easily writing data to the vault
                      via spool files. Includes automatic spool file rotation,


### PR DESCRIPTION
Replaced the chained transformers with RWST
Remove -j option when runCollectorN is not used
Removed the standalone deriving clauses for Collector and converted to regular derivation
